### PR TITLE
Backslashes in $path are not accepted as URL (Windows-based server) - CSS absolutiser

### DIFF
--- a/filters/CssUrlsFilter.php
+++ b/filters/CssUrlsFilter.php
@@ -37,6 +37,9 @@ class CssUrlsFilter extends \Nette\Object {
 			$path = $basePath . substr($sourcePath, strlen($docroot)) . DIRECTORY_SEPARATOR . $url;
 		}
 
+		// Replace backslashes in $path
+		$path = str_replace('\\', '/', $path);
+
 		//$path = self::cannonicalizePath($path);
 
 		return $quote === '"' ? addslashes($path) : $path;


### PR DESCRIPTION
Backslashe prostě při absolutizaci dělají bordel (cokoliv nalinkovaného do CSS se nenačetlo), vyřešil jsem to jednoduchým str_replace a nezdá se, že by byly problémy...
