### PR TITLE
LessFilter now parses whole file - fixes case when @var defined in another *.less file

### DIFF
--- a/WebLoader/Filter/LessFilter.php
+++ b/WebLoader/Filter/LessFilter.php
@@ -38,14 +38,20 @@ class LessFilter
 	 * @param string $file
 	 * @return string
 	 */
-	public function __invoke($code, \WebLoader\Compiler $loader, $file)
+	public function __invoke($code, \WebLoader\Compiler $loader, $file = NULL)
 	{
-		if (pathinfo($file, PATHINFO_EXTENSION) === 'less') {
-			$this->getLessC()->importDir = pathinfo($file, PATHINFO_DIRNAME) . '/';
+		if ($file) {
+			if (pathinfo($file, PATHINFO_EXTENSION) === 'less') {
+				$this->getLessC()->importDir = pathinfo($file, PATHINFO_DIRNAME) . '/';
+				return $this->getLessC()->parse($code);
+
+			} else {
+				return $code;
+			}
+
+		} else {
 			return $this->getLessC()->parse($code);
 		}
-
-		return $code;
 	}
 
 }


### PR DESCRIPTION
Fixes this use case:

```
files:
    - css/base.less # defines @color1, @color2...
    - css/footer.less # uses @color1, which throws error
```
