### PR TITLE
Fixes multiple import of same file in LessCSS

### DIFF
--- a/WebLoader/Filter/LessFilter.php
+++ b/WebLoader/Filter/LessFilter.php
@@ -13,7 +13,7 @@ class LessFilter
 
 	private $lc;
 
-	public function __construct(\lessc $lc = null)
+	public function __construct(\lessc $lc = NULL)
 	{
 		$this->lc = $lc;
 	}


### PR DESCRIPTION
Pokud pouzijeme import jednoho souboru s funkcema do dvou ruznych Less
souboru, provede se import pouze do prvniho, v druhem jiz instance lessc
pozna, ze soubor byl importovan a vynecha jeho import, je proto treba
pro kazdy soubor vytvorit novou instanci lessc, tak aby byl vzdy soubor
importovan
