### PR TITLE
obsolete empty script not rendered when no non-remote files given

### DIFF
--- a/WebLoader/Compiler.php
+++ b/WebLoader/Compiler.php
@@ -167,14 +167,21 @@ class Compiler
 	 */
 	public function generate($ifModified = TRUE)
 	{
+		$files = $this->collection->getFiles();
+
+		if (!count($files)) {
+			return array();
+		}
+
 		if ($this->joinFiles) {
 			return array(
-				$this->generateFiles($this->collection->getFiles(), $ifModified)
+				$this->generateFiles($files, $ifModified),
 			);
+
 		} else {
 			$arr = array();
 
-			foreach ($this->collection->getFiles() as $file) {
+			foreach ($files as $file) {
 				$arr[] = $this->generateFiles(array($file), $ifModified);
 			}
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -54,6 +54,16 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals(1, count($this->getTempFiles()), 'Multiple files are generated instead of join.');
 	}
 
+	public function testEmptyFiles()
+	{
+		$this->assertTrue($this->object->getJoinFiles());
+		$this->object->setFileCollection(new \WebLoader\FileCollection());
+
+		$ret = $this->object->generate();
+		$this->assertEquals(0, count($ret));
+		$this->assertEquals(0, count($this->getTempFiles()));
+	}
+
 	public function testNotJoinFiles()
 	{
 		$this->object->setJoinFiles(FALSE);


### PR DESCRIPTION
Use case: only remote files present (so that Compiler does not have anything to render with joinFiles = TRUE)
