### PR TITLE
Add a PHP-based coffeescript compiler filter

### DIFF
--- a/WebLoader/Filter/CoffeeScriptPhpFilter.php
+++ b/WebLoader/Filter/CoffeeScriptPhpFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WebLoader\Filter;
+use CoffeeScript;
+
+/**
+ * Coffee script filter using a PHP-based compiler
+ *
+ * @author Jan Buchar
+ * @license MIT
+ */
+class CoffeeScriptPhpFilter
+{
+	/**
+	 * Invoke filter
+	 *
+	 * @param string
+	 * @param \WebLoader\Compiler
+	 * @param string
+	 * @return string
+	 */
+	public function __invoke($code, \WebLoader\Compiler $loader, $file = NULL)
+	{
+		if (pathinfo($file, PATHINFO_EXTENSION) === 'coffee') {
+			$code = $this->compileCoffee($code, $file);
+		}
+
+		return $code;
+	}
+
+	/**
+	 * @param string
+	 * @return string
+	 */
+	protected function compileCoffee($source, $file)
+	{
+		return CoffeeScript\Compiler::compile($source, array('filename' => $file));
+	}
+
+}


### PR DESCRIPTION
This gives the poor souls, who have to use inferior webhosting services, an opportunity to use CoffeeScript.
Requires `coffeescript/coffeescript`.
