### PR TITLE
Ensure file list sets up to Nette in the proper order

### DIFF
--- a/WebLoader/Nette/Extension.php
+++ b/WebLoader/Nette/Extension.php
@@ -110,9 +110,17 @@ class Extension extends CompilerExtension
 					$finder->from(is_dir($file['from']) ? $file['from'] : $config['sourceDir'] . DIRECTORY_SEPARATOR . $file['from']);
 				}
 
+				$foundFilesList = array();
+
 				foreach ($finder as $foundFile) {
 					/** @var \SplFileInfo $foundFile */
-					$files->addSetup('addFile', array($foundFile->getPathname()));
+					$foundFilesList[] = $foundFile->getPathname();
+				}
+
+				sort($foundFilesList);
+
+				foreach ($foundFilesList as $foundFilePathname) {
+					$files->addSetup('addFile', array($foundFilePathname));
 				}
 
 			} else {


### PR DESCRIPTION
Due to the nature of FilesystemIterator used in `Nette::Finder` to fetch a list of files from a directory, file list comes unsorted at all. This PR adds defensive code to ensure files setup in the order we want to prevent possible clashes between javascripts and be sure CSS rules are overwritten in the proper order if required so.