### PR TITLE
Extension: fixed extension name independency

### DIFF
--- a/WebLoader/Nette/Extension.php
+++ b/WebLoader/Nette/Extension.php
@@ -97,7 +97,7 @@ class Extension extends CompilerExtension
 		}
 
 		$builder->addDefinition($this->prefix('factory'))
-			->setClass('WebLoader\Nette\LoaderFactory', array($loaderFactoryTempPaths));
+			->setClass('WebLoader\Nette\LoaderFactory', array($loaderFactoryTempPaths, $this->name));
 	}
 
 	private function addWebLoader(ContainerBuilder $builder, $name, $config)

--- a/WebLoader/Nette/LoaderFactory.php
+++ b/WebLoader/Nette/LoaderFactory.php
@@ -18,16 +18,21 @@ class LoaderFactory
 	/** @var array */
 	private $tempPaths;
 
+	/** @var string */
+	private $extensionName;
+
 	/**
 	 * @param array $tempPaths
+	 * @param string $extensionName
 	 * @param IRequest $httpRequest
 	 * @param Container $serviceLocator
 	 */
-	public function __construct(array $tempPaths, IRequest $httpRequest, Container $serviceLocator)
+	public function __construct(array $tempPaths, $extensionName, IRequest $httpRequest, Container $serviceLocator)
 	{
 		$this->httpRequest = $httpRequest;
 		$this->serviceLocator = $serviceLocator;
 		$this->tempPaths = $tempPaths;
+		$this->extensionName = $extensionName;
 	}
 
 	/**
@@ -37,7 +42,7 @@ class LoaderFactory
 	public function createCssLoader($name)
 	{
 		/** @var Compiler $compiler */
-		$compiler = $this->serviceLocator->getService('webloader.css' . ucfirst($name) . 'Compiler');
+		$compiler = $this->serviceLocator->getService($this->extensionName . '.css' . ucfirst($name) . 'Compiler');
 		return new CssLoader($compiler, $this->formatTempPath($name));
 	}
 
@@ -48,7 +53,7 @@ class LoaderFactory
 	public function createJavaScriptLoader($name)
 	{
 		/** @var Compiler $compiler */
-		$compiler = $this->serviceLocator->getService('webloader.js' . ucfirst($name) . 'Compiler');
+		$compiler = $this->serviceLocator->getService($this->extensionName . '.js' . ucfirst($name) . 'Compiler');
 		return new JavaScriptLoader($compiler, $this->formatTempPath($name));
 	}
 

--- a/tests/Nette/ExtensionTest.php
+++ b/tests/Nette/ExtensionTest.php
@@ -77,4 +77,22 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
 		$this->assertFalse($this->container->getService('webloader.cssJoinOffCompiler')->getJoinFiles());
 	}
 
+	public function testExtensionName()
+	{
+		$tempDir = __DIR__ . '/../temp';
+		$class = 'ExtensionNameServiceContainer';
+
+		$configurator = new \Nette\Configurator();
+		$configurator->setTempDirectory($tempDir);
+		$configurator->addParameters(array('container' => array('class' => $class)));
+		$configurator->onCompile[] = function ($configurator, \Nette\DI\Compiler $compiler) {
+			$compiler->addExtension('Foo', new \WebLoader\Nette\Extension());
+		};
+		$configurator->addConfig(__DIR__ . '/../fixtures/extensionName.neon', false);
+		$container = $configurator->createContainer();
+
+		$this->assertInstanceOf('WebLoader\Compiler', $container->getService('Foo.cssDefaultCompiler'));
+		$this->assertInstanceOf('WebLoader\Compiler', $container->getService('Foo.jsDefaultCompiler'));
+	}
+
 }

--- a/tests/fixtures/extensionName.neon
+++ b/tests/fixtures/extensionName.neon
@@ -1,0 +1,15 @@
+Foo:
+  cssDefaults:
+    sourceDir: %appDir%/../fixtures
+    tempDir: %appDir%/../temp
+  jsDefaults:
+    sourceDir: %appDir%/../fixtures
+    tempDir: %appDir%/../temp
+  css:
+    default:
+      files:
+        - dir/one.css
+  js:
+    default:
+      files:
+        - dir/one.js


### PR DESCRIPTION
Due to https://github.com/janmarek/WebLoader/blob/master/WebLoader/Nette/LoaderFactory.php#L40 I was not able to use custom name for this extension.

NOTE: I was not able to run tests on win ^^