### PR TITLE
Fix Path::normalize() stripping folders named '0' [fixes #112]

### DIFF
--- a/WebLoader/Path.php
+++ b/WebLoader/Path.php
@@ -13,7 +13,7 @@ class Path
 		$res = array();
 
 		foreach ($pieces as $piece) {
-			if ($piece === '.' || empty($piece)) {
+			if ($piece === '.' || $piece === '') {
 				continue;
 			}
 			if ($piece === '..') {

--- a/tests/Path/PathTest.php
+++ b/tests/Path/PathTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WebLoader\Test\Path;
+
+use WebLoader\Path;
+
+class PathTest extends \PHPUnit_Framework_TestCase
+{
+
+	public function testNormalize()
+	{
+		$normalized = Path::normalize('/path/to//project//that/contains/0/in/it');
+		$this->assertEquals('/path/to/project/that/contains/0/in/it', $normalized);
+	}
+
+}


### PR DESCRIPTION
When running tests on Gitlab CI, Gitlab creates temporary folders like this:

`/path/to/builds/0/build`

and `Path::normalize('/path/to/builds/0/build');` returns wrong path without folder named `"0"`.
it is caused by `empty()` function: `empty('0') === TRUE`