### PR TITLE
Close #114 Unable to import file defined by absolute url via ScssFilter

### DIFF
--- a/WebLoader/Filter/ScssFilter.php
+++ b/WebLoader/Filter/ScssFilter.php
@@ -44,7 +44,7 @@ class ScssFilter
 	public function __invoke($code, \WebLoader\Compiler $loader, $file)
 	{
 		if (pathinfo($file, PATHINFO_EXTENSION) === 'scss') {
-			$this->getScssC()->setImportPaths(pathinfo($file, PATHINFO_DIRNAME) . '/');
+			$this->getScssC()->setImportPaths(array('', pathinfo($file, PATHINFO_DIRNAME) . '/'));
 			return $this->getScssC()->compile($code);
 		}
 

--- a/tests/Filter/ScssFilterTest.php
+++ b/tests/Filter/ScssFilterTest.php
@@ -6,6 +6,7 @@ use WebLoader\Compiler;
 use WebLoader\DefaultOutputNamingConvention;
 use WebLoader\FileCollection;
 use WebLoader\Filter\ScssFilter;
+use WebLoader\Filter\VariablesFilter;
 
 class ScssFilterTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,6 +30,18 @@ class ScssFilterTest extends \PHPUnit_Framework_TestCase
 		$file = __DIR__ . '/../fixtures/style.scss';
 		$less = $this->filter->__invoke(file_get_contents($file), $this->compiler, $file);
 		$this->assertSame(file_get_contents(__DIR__ . '/../fixtures/style.scss.expected'), $less);
+	}
+
+	public function testImportAbsolutePath()
+	{
+		$file = __DIR__ . '/../fixtures/styleAbsolute.scss';
+		$filter = new VariablesFilter(array(
+			'fixturesAbsolutePath' => realpath(__DIR__.'/../fixtures'),
+		));
+		$code = file_get_contents($file);
+		$filtered = $filter($code);
+		$less = $this->filter->__invoke($filtered, $this->compiler, $file);
+		$this->assertSame(file_get_contents(__DIR__ . '/../fixtures/styleAbsolute.scss.expected'), $less);
 	}
 
 }

--- a/tests/fixtures/styleAbsolute.scss
+++ b/tests/fixtures/styleAbsolute.scss
@@ -1,0 +1,19 @@
+
+@import '{{$fixturesAbsolutePath}}/style2.scss';
+
+.navigation {
+    ul {
+        line-height: 20px;
+        color: blue;
+        a {
+            color: red;
+        }
+    }
+}
+
+.footer {
+    .copyright {
+        color: silver;
+    }
+}
+

--- a/tests/fixtures/styleAbsolute.scss.expected
+++ b/tests/fixtures/styleAbsolute.scss.expected
@@ -1,0 +1,12 @@
+.clearFix {
+  display: block;
+  zoom: 1; }
+
+.navigation ul {
+  line-height: 20px;
+  color: blue; }
+  .navigation ul a {
+    color: red; }
+
+.footer .copyright {
+  color: silver; }


### PR DESCRIPTION
When I tried to debug the core of the problem, I found, that `\Leafo\ScssPhp\Compiler` have `protected $importPaths = array('');` by default.

But calling `setImportPaths(pathinfo($file, PATHINFO_DIRNAME) . '/')` in `WebLoader/Filter/ScssFilter` remove the empty path required for import from the absolute path.