### PR TITLE
Param tempPath is taken right [Fixes #120]

### DIFF
--- a/WebLoader/Nette/Extension.php
+++ b/WebLoader/Nette/Extension.php
@@ -88,7 +88,7 @@ class Extension extends CompilerExtension
 			foreach ($config[$type] as $name => $wlConfig) {
 				$wlConfig = Helpers::merge($wlConfig, $config[$type . 'Defaults']);
 				$this->addWebLoader($builder, $type . ucfirst($name), $wlConfig);
-				$loaderFactoryTempPaths[strtolower($name)] = $wlConfig['tempPath'];
+				$loaderFactoryTempPaths[$type][strtolower($name)] = $wlConfig['tempPath'];
 
 				if (!is_dir($wlConfig['tempDir']) || !is_writable($wlConfig['tempDir'])) {
 					throw new CompilationException(sprintf("You must create a writable directory '%s'", $wlConfig['tempDir']));

--- a/WebLoader/Nette/LoaderFactory.php
+++ b/WebLoader/Nette/LoaderFactory.php
@@ -43,7 +43,7 @@ class LoaderFactory
 	{
 		/** @var Compiler $compiler */
 		$compiler = $this->serviceLocator->getService($this->extensionName . '.css' . ucfirst($name) . 'Compiler');
-		return new CssLoader($compiler, $this->formatTempPath($name));
+		return new CssLoader($compiler, $this->formatTempPath('css', $name));
 	}
 
 	/**
@@ -54,17 +54,17 @@ class LoaderFactory
 	{
 		/** @var Compiler $compiler */
 		$compiler = $this->serviceLocator->getService($this->extensionName . '.js' . ucfirst($name) . 'Compiler');
-		return new JavaScriptLoader($compiler, $this->formatTempPath($name));
+		return new JavaScriptLoader($compiler, $this->formatTempPath('js', $name));
 	}
 
 	/**
 	 * @param string $name
 	 * @return string
 	 */
-	private function formatTempPath($name)
+	private function formatTempPath($type, $name)
 	{
 		$lName = strtolower($name);
-		$tempPath = isset($this->tempPaths[$lName]) ? $this->tempPaths[$lName] : Extension::DEFAULT_TEMP_PATH;
+		$tempPath = isset($this->tempPaths[$type][$lName]) ? $this->tempPaths[$type][$lName] : Extension::DEFAULT_TEMP_PATH;
 		return rtrim($this->httpRequest->getUrl()->basePath, '/') . '/' . $tempPath;
 	}
 


### PR DESCRIPTION
#120 - When tempPath was set in neon in JS and CSS section, first occurrence was
  overwritten by last occurrence.