### PR TITLE
[Fix] Change deprecated $class->properties call

### DIFF
--- a/WebLoader/Nette/Extension.php
+++ b/WebLoader/Nette/Extension.php
@@ -154,7 +154,7 @@ class Extension extends CompilerExtension
 
 	public function afterCompile(Nette\PhpGenerator\ClassType $class)
 	{
-		$meta = $class->properties['meta'];
+		$meta = $class->getProperties()['meta'];
 		if (array_key_exists('webloader\\nette\\loaderfactory', $meta->value['types'])) {
 			$meta->value['types']['webloader\\loaderfactory'] = $meta->value['types']['webloader\\nette\\loaderfactory'];
 		}


### PR DESCRIPTION
Updated to $class->getProperties() to avoid "User Deprecated: Missing annotation @property for Nette\PhpGenerator\ClassType::$properties" exception.
![snimek obrazovky porizeny 2016-06-26 00 26 50](https://cloud.githubusercontent.com/assets/4839429/16359423/b82de5aa-3b34-11e6-8b82-e4c5d0b7e3fc.png)
