### PR TITLE
Fix Nette\Extension: missing annotation property

### DIFF
--- a/WebLoader/Nette/Extension.php
+++ b/WebLoader/Nette/Extension.php
@@ -154,7 +154,7 @@ class Extension extends CompilerExtension
 
 	public function afterCompile(Nette\PhpGenerator\ClassType $class)
 	{
-		$meta = $class->properties['meta'];
+		$meta = $class->getProperty('meta');
 		if (array_key_exists('webloader\\nette\\loaderfactory', $meta->value['types'])) {
 			$meta->value['types']['webloader\\loaderfactory'] = $meta->value['types']['webloader\\nette\\loaderfactory'];
 		}


### PR DESCRIPTION
Nette 2.4 - Missing annotation @property for Nette\PhpGenerator\ClassType::$properties used in .../WebLoader/Nette/Extension.php:157