### PR TITLE
Fix last modified time in the url if checkLastModified is false

### DIFF
--- a/WebLoader/Compiler.php
+++ b/WebLoader/Compiler.php
@@ -216,7 +216,7 @@ class Compiler
 
 		return (object) array(
 			'file' => $name,
-			'lastModified' => $lastModified,
+			'lastModified' => filemtime($path),
 			'sourceFiles' => $files,
 		);
 	}

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -107,7 +107,7 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
 
 		$files = $this->object->generate();
 
-		$this->assertTrue(is_numeric($files[0]->lastModified), 'Generate does not provide last modified timestamp correctly.');
+		$this->assertTrue(is_numeric($files[0]->lastModified) && $files[0]->lastModified > 0, 'Generate does not provide last modified timestamp correctly.');
 
 		$content = file_get_contents($this->object->getOutputDir() . '/' . $files[0]->file);
 


### PR DESCRIPTION
Now url contains zero, not last modified time.
cssloader-2d0ad71cc7b9.css?0

If file is changed, it will stay in browser cache.



